### PR TITLE
Add OpenCensus extension PHP classes

### DIFF
--- a/ext/link.php
+++ b/ext/link.php
@@ -20,18 +20,10 @@ namespace OpenCensus\Trace\Ext;
 /**
  * This is the equivalent PHP class created by the opencensus C extension
  */
-class Span {
-    protected $name = "unknown";
+class Link {
+    protected $traceId;
     protected $spanId;
-    protected $parentSpanId;
-    protected $startTime;
-    protected $endTime;
-    protected $attributes;
-    protected $stackTrace;
-    /** @var Link[] */
-    protected $links;
-    protected $timeEvents;
-    protected $kind;
+    protected $options;
 
     public function __construct(array $spanOptions)
     {
@@ -40,9 +32,9 @@ class Span {
         }
     }
 
-    public function name()
+    public function traceId()
     {
-        return $this->name;
+        return $this->spanId;
     }
 
     public function spanId()
@@ -50,43 +42,8 @@ class Span {
         return $this->spanId;
     }
 
-    public function parentSpanId()
+    public function options()
     {
-        return $this->parentSpanId;
-    }
-
-    public function startTime()
-    {
-        return $this->startTime;
-    }
-
-    public function endTime()
-    {
-        return $this->endTime;
-    }
-
-    public function attributes()
-    {
-        return $this->attributes;
-    }
-
-    public function stackTrace()
-    {
-        return $this->stackTrace;
-    }
-
-    public function links()
-    {
-        return $this->links;
-    }
-
-    public function timeEvents()
-    {
-        return $this->timeEvents;
-    }
-
-    public function kind()
-    {
-        return $this->kind;
+        return $this->options;
     }
 }

--- a/ext/time_event.php
+++ b/ext/time_event.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Ext;
+
+/**
+ * This is the equivalent PHP class created by the opencensus C extension
+ */
+class TimeEvent {
+    protected $options;
+    protected $time;
+    protected $type;
+    protected $id;
+
+    public function __construct(array $spanOptions)
+    {
+        foreach ($spanOptions as $k => $v) {
+            $this->__set($k, $v);
+        }
+    }
+
+    public function options()
+    {
+        return $this->options;
+    }
+
+    public function time()
+    {
+        return $this->time;
+    }
+
+    public function description()
+    {
+        return $this->time;
+    }
+
+    public function type()
+    {
+        return $this->type;
+    }
+
+    public function id()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
This stops the IDE from complaining that some classes don't exist
or have no methods.