### PR TITLE
Update PropagatorInterface

### DIFF
--- a/src/Core/Scope.php
+++ b/src/Core/Scope.php
@@ -58,7 +58,7 @@ class Scope
     /**
      * Close and clean up the scope. Runs the initial callback provided.
      */
-    public function close()
+    public function close(): void
     {
         call_user_func_array($this->callback, $this->args);
     }

--- a/src/Trace/Integrations/Guzzle/EventSubscriber.php
+++ b/src/Trace/Integrations/Guzzle/EventSubscriber.php
@@ -18,6 +18,7 @@
 namespace OpenCensus\Trace\Integrations\Guzzle;
 
 use OpenCensus\Core\Scope;
+use OpenCensus\Trace\Propagator\ArrayHeaders;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\Tracer;
 use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
@@ -88,8 +89,9 @@ class EventSubscriber implements SubscriberInterface
         $request = $event->getRequest();
         $context = Tracer::spanContext();
         if ($context->enabled()) {
+            $headers = new ArrayHeaders();
             $this->propagator->inject($context, $headers);
-            $request->setHeaders($headers);
+            $request->setHeaders($headers->toArray());
         }
 
         $span = Tracer::startSpan([

--- a/src/Trace/Integrations/Guzzle/Middleware.php
+++ b/src/Trace/Integrations/Guzzle/Middleware.php
@@ -17,6 +17,7 @@
 
 namespace OpenCensus\Trace\Integrations\Guzzle;
 
+use OpenCensus\Trace\Propagator\ArrayHeaders;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\Tracer;
 use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
@@ -70,8 +71,8 @@ class Middleware
         return function (RequestInterface $request, $options) use ($handler) {
             $context = Tracer::spanContext();
             if ($context->enabled()) {
+                $headers = new ArrayHeaders();
                 $this->propagator->inject($context, $headers) ;
-
                 foreach ($headers as $headerName => $headerValue) {
                     $request = $request->withHeader($headerName, $headerValue);
                 }

--- a/src/Trace/Propagator/ArrayHeaders.php
+++ b/src/Trace/Propagator/ArrayHeaders.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace OpenCensus\Trace\Propagator;
+
+class ArrayHeaders implements HeaderSetter, HeaderGetter, \IteratorAggregate, \ArrayAccess
+{
+    /**
+     * @var string[]
+     */
+    private $headers;
+
+    /**
+     * @param string[] $headers An associative array with header name as key
+     */
+    public function __construct(array $headers = [])
+    {
+        $this->headers = $headers;
+    }
+
+    public function get(string $header): ?string
+    {
+        return $this->headers[$header] ?? null;
+    }
+
+    public function set(string $header, string $value): void
+    {
+        $this->headers[$header] = $value;
+    }
+
+    public function toArray(): array
+    {
+        return $this->headers;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->headers);
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->headers[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->set($offset, $value);
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->headers[$offset]);
+    }
+}

--- a/src/Trace/Propagator/B3HeadersPropagator.php
+++ b/src/Trace/Propagator/B3HeadersPropagator.php
@@ -14,12 +14,12 @@ class B3HeadersPropagator implements PropagatorInterface
     private const X_B3_SAMPLED = 'X-B3-Sampled';
     private const X_B3_FLAGS = 'X-B3-Flags';
 
-    public function extract($container): SpanContext
+    public function extract(HeaderGetter $headers): SpanContext
     {
-        $traceId = $container[self::X_B3_TRACE_ID] ?? null;
-        $spanId = $container[self::X_B3_SPAN_ID] ?? null;
-        $sampled = $container[self::X_B3_SAMPLED] ?? null;
-        $flags = $container[self::X_B3_FLAGS] ?? null;
+        $traceId = $headers->get(self::X_B3_TRACE_ID);
+        $spanId = $headers->get(self::X_B3_SPAN_ID);
+        $sampled = $headers->get(self::X_B3_SAMPLED);
+        $flags = $headers->get(self::X_B3_FLAGS);
 
         if (!$traceId || !$spanId) {
             return new SpanContext();
@@ -38,10 +38,10 @@ class B3HeadersPropagator implements PropagatorInterface
         return new SpanContext($traceId, $spanId, $enabled, true);
     }
 
-    public function inject(SpanContext $context, &$container): void
+    public function inject(SpanContext $context, HeaderSetter $headers): void
     {
-        $container[self::X_B3_TRACE_ID] = $context->traceId();
-        $container[self::X_B3_SPAN_ID] = $context->spanId();
-        $container[self::X_B3_SAMPLED] = $context->enabled() ? 1 : 0;
+        $headers->set(self::X_B3_TRACE_ID, $context->traceId());
+        $headers->set(self::X_B3_SPAN_ID, $context->spanId());
+        $headers->set(self::X_B3_SAMPLED, $context->enabled() ? 1 : 0);
     }
 }

--- a/src/Trace/Propagator/HeaderGetter.php
+++ b/src/Trace/Propagator/HeaderGetter.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace OpenCensus\Trace\Propagator;
+
+interface HeaderGetter
+{
+    /**
+     * @param string $header Header name
+     * @return string|null
+     */
+    public function get(string $header): ?string;
+}

--- a/src/Trace/Propagator/HeaderSetter.php
+++ b/src/Trace/Propagator/HeaderSetter.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace OpenCensus\Trace\Propagator;
+
+interface HeaderSetter
+{
+    /**
+     * @param string $header Header name
+     * @param string $value Header value
+     */
+    public function set(string $header, string $value): void;
+}

--- a/src/Trace/Propagator/PropagatorInterface.php
+++ b/src/Trace/Propagator/PropagatorInterface.php
@@ -29,16 +29,16 @@ interface PropagatorInterface
     /**
      * Extract the SpanContext from some container
      *
-     * @param mixed $container
+     * @param HeaderGetter $getter
      * @return SpanContext
      */
-    public function extract($container): SpanContext;
+    public function extract(HeaderGetter $getter): SpanContext;
 
     /**
-     * Inject the SpanContext back into the response
+     * Inject the SpanContext back into the container
      *
      * @param SpanContext $context
-     * @param mixed $container An object in which the SpanContext data will be injected.
+     * @param HeaderSetter $setter
      */
-    public function inject(SpanContext $context, &$container): void;
+    public function inject(SpanContext $context, HeaderSetter $setter): void;
 }

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -17,12 +17,10 @@
 
 namespace OpenCensus\Trace;
 
-use OpenCensus\Core\Context;
 use OpenCensus\Core\Scope;
 use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\Propagator\ArrayHeaders;
 use OpenCensus\Trace\Sampler\SamplerInterface;
-use OpenCensus\Trace\Span;
 use OpenCensus\Trace\Tracer\ContextTracer;
 use OpenCensus\Trace\Tracer\ExtensionTracer;
 use OpenCensus\Trace\Tracer\NullTracer;
@@ -36,8 +34,8 @@ use OpenCensus\Trace\Propagator\PropagatorInterface;
  */
 class RequestHandler
 {
-    const DEFAULT_ROOT_SPAN_NAME = 'main';
-    const ATTRIBUTE_MAP = [
+    private const DEFAULT_ROOT_SPAN_NAME = 'main';
+    private const ATTRIBUTE_MAP = [
         Span::ATTRIBUTE_HOST => ['HTTP_HOST', 'SERVER_NAME'],
         Span::ATTRIBUTE_PORT => ['SERVER_PORT'],
         Span::ATTRIBUTE_METHOD => ['REQUEST_METHOD'],
@@ -131,7 +129,7 @@ class RequestHandler
      * reports using the provided ExporterInterface. Adds additional attributes to
      * the root span detected from the response.
      */
-    public function onExit()
+    public function onExit(): void
     {
         $this->addCommonRequestAttributes($this->headers->toArray());
 
@@ -145,7 +143,7 @@ class RequestHandler
      *
      * @return TracerInterface
      */
-    public function tracer()
+    public function tracer(): TracerInterface
     {
         return $this->tracer;
     }
@@ -159,6 +157,7 @@ class RequestHandler
      * @param array $spanOptions Options for the span. See
      *        <a href="Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
      * @param callable $callable The callable to instrument.
+     * @param array $arguments
      * @return mixed Returns whatever the callable returns
      */
     public function inSpan(array $spanOptions, callable $callable, array $arguments = [])
@@ -174,7 +173,7 @@ class RequestHandler
      *        <a href="Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
      * @return Span
      */
-    public function startSpan(array $spanOptions = [])
+    public function startSpan(array $spanOptions = []): Span
     {
         return $this->tracer->startSpan($spanOptions);
     }
@@ -186,7 +185,7 @@ class RequestHandler
      * @param Span $span
      * @return Scope
      */
-    public function withSpan(Span $span)
+    public function withSpan(Span $span): Scope
     {
         return $this->tracer->withSpan($span);
     }
@@ -200,7 +199,7 @@ class RequestHandler
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public function addAttribute($attribute, $value, $options = [])
+    public function addAttribute($attribute, $value, $options = []): void
     {
         $this->tracer->addAttribute($attribute, $value, $options);
     }
@@ -215,7 +214,7 @@ class RequestHandler
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addAnnotation($description, $options = [])
+    public function addAnnotation($description, $options = []): void
     {
         $this->tracer->addAnnotation($description, $options);
     }
@@ -233,7 +232,7 @@ class RequestHandler
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addLink($traceId, $spanId, $options = [])
+    public function addLink($traceId, $spanId, $options = []): void
     {
         $this->tracer->addLink($traceId, $spanId, $options);
     }
@@ -253,12 +252,12 @@ class RequestHandler
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addMessageEvent($type, $id, $options)
+    public function addMessageEvent($type, $id, $options): void
     {
         $this->tracer->addMessageEvent($type, $id, $options);
     }
 
-    public function addCommonRequestAttributes(array $headers)
+    private function addCommonRequestAttributes(array $headers): void
     {
         if ($responseCode = http_response_code()) {
             $this->rootSpan->setStatus($responseCode, "HTTP status code: $responseCode");
@@ -275,7 +274,7 @@ class RequestHandler
         }
     }
 
-    private function startTimeFromHeaders(array $headers)
+    private function startTimeFromHeaders(array $headers): ?string
     {
         if (array_key_exists('REQUEST_TIME_FLOAT', $headers)) {
             return $headers['REQUEST_TIME_FLOAT'];
@@ -286,15 +285,12 @@ class RequestHandler
         return null;
     }
 
-    private function nameFromHeaders(array $headers)
+    private function nameFromHeaders(array $headers): string
     {
-        if (array_key_exists('REQUEST_URI', $headers)) {
-            return $headers['REQUEST_URI'];
-        }
-        return self::DEFAULT_ROOT_SPAN_NAME;
+        return $headers['REQUEST_URI'] ?? self::DEFAULT_ROOT_SPAN_NAME;
     }
 
-    private function detectKey(array $keys, array $array)
+    private function detectKey(array $keys, array $array): ?string
     {
         foreach ($keys as $key) {
             if (array_key_exists($key, $array)) {

--- a/src/Trace/Tracer.php
+++ b/src/Trace/Tracer.php
@@ -18,7 +18,6 @@
 namespace OpenCensus\Trace;
 
 use OpenCensus\Core\Scope;
-use OpenCensus\Trace\Span;
 use OpenCensus\Trace\Sampler\AlwaysSampleSampler;
 use OpenCensus\Trace\Sampler\SamplerInterface;
 use OpenCensus\Trace\Exporter\ExporterInterface;
@@ -117,7 +116,7 @@ class Tracer
      *      @type array $headers Optional array of headers to use in place of $_SERVER
      * @return RequestHandler
      */
-    public static function start(ExporterInterface $reporter, array $options = [])
+    public static function start(ExporterInterface $reporter, array $options = []): RequestHandler
     {
         $sampler = array_key_exists('sampler', $options)
             ? $options['sampler']
@@ -187,12 +186,9 @@ class Tracer
      *      <a href="Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
      * @return Span
      */
-    public static function startSpan(array $spanOptions = [])
+    public static function startSpan(array $spanOptions = []): Span
     {
-        if (!isset(self::$instance)) {
-            return new Span();
-        }
-        return self::$instance->startSpan($spanOptions);
+        return isset(self::$instance) ? self::$instance->startSpan($spanOptions) : new Span();
     }
 
     /**
@@ -213,13 +209,12 @@ class Tracer
      * @param Span $span
      * @return Scope
      */
-    public static function withSpan(Span $span)
+    public static function withSpan(Span $span): Scope
     {
-        if (!isset(self::$instance)) {
-            return new Scope(function () {
-            });
-        }
-        return self::$instance->withSpan($span);
+        return isset(self::$instance) ? self::$instance->withSpan($span) : new Scope(
+            function () {
+            }
+        );
     }
 
     /**
@@ -231,12 +226,11 @@ class Tracer
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public static function addAttribute($attribute, $value, $options = [])
+    public static function addAttribute($attribute, $value, $options = []): void
     {
-        if (!isset(self::$instance)) {
-            return;
+        if (isset(self::$instance)) {
+            self::$instance->addAttribute($attribute, $value, $options);
         }
-        return self::$instance->addAttribute($attribute, $value, $options);
     }
 
     /**
@@ -249,12 +243,11 @@ class Tracer
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public static function addAnnotation($description, $options = [])
+    public static function addAnnotation($description, $options = []): void
     {
-        if (!isset(self::$instance)) {
-            return;
+        if (isset(self::$instance)) {
+            self::$instance->addAnnotation($description, $options);
         }
-        return self::$instance->addAnnotation($description, $options);
     }
 
     /**
@@ -270,12 +263,11 @@ class Tracer
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public static function addLink($traceId, $spanId, $options = [])
+    public static function addLink($traceId, $spanId, $options = []): void
     {
-        if (!isset(self::$instance)) {
-            return;
+        if (isset(self::$instance)) {
+            self::$instance->addLink($traceId, $spanId, $options);
         }
-        return self::$instance->addLink($traceId, $spanId, $options);
     }
 
     /**
@@ -293,12 +285,11 @@ class Tracer
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public static function addMessageEvent($type, $id, $options = [])
+    public static function addMessageEvent($type, $id, $options = []): void
     {
-        if (!isset(self::$instance)) {
-            return;
+        if (isset(self::$instance)) {
+            self::$instance->addMessageEvent($type, $id, $options);
         }
-        return self::$instance->addMessageEvent($type, $id, $options);
     }
 
     /**
@@ -306,11 +297,8 @@ class Tracer
      *
      * @return SpanContext
      */
-    public static function spanContext()
+    public static function spanContext(): SpanContext
     {
-        if (!isset(self::$instance)) {
-            return new SpanContext(null, null, false);
-        }
-        return self::$instance->tracer()->spanContext();
+        return isset(self::$instance) ? self::$instance->tracer()->spanContext() : new SpanContext(null, null, false);
     }
 }

--- a/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
+++ b/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
@@ -22,6 +22,7 @@ use OpenCensus\Trace\Tracer;
 use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\Integrations\Guzzle\Middleware;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,9 @@ use PHPUnit\Framework\TestCase;
  */
 class MiddlewareTest extends TestCase
 {
+    /**
+     * @var ExporterInterface|ObjectProphecy
+     */
     private $exporter;
 
     public function setUp()

--- a/tests/unit/Trace/Propagator/B3HeadersPropagatorTest.php
+++ b/tests/unit/Trace/Propagator/B3HeadersPropagatorTest.php
@@ -2,8 +2,8 @@
 
 namespace OpenCensus\Tests\Unit\Trace\Propagator;
 
+use OpenCensus\Trace\Propagator\ArrayHeaders;
 use OpenCensus\Trace\Propagator\B3HeadersPropagator;
-use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
 use OpenCensus\Trace\SpanContext;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +18,7 @@ class B3HeadersPropagatorTest extends TestCase
     public function testExtract($traceId, $spanId, $enabled, $headers)
     {
         $propagator = new B3HeadersPropagator();
-        $context = $propagator->extract($headers);
+        $context = $propagator->extract(new ArrayHeaders($headers));
         $this->assertEquals($traceId, $context->traceId());
         $this->assertEquals($spanId, $context->spanId());
         $this->assertEquals($enabled, $context->enabled());
@@ -28,7 +28,7 @@ class B3HeadersPropagatorTest extends TestCase
     public function testExtractWithoutHeaders()
     {
         $propagator = new B3HeadersPropagator();
-        $context = $propagator->extract([]);
+        $context = $propagator->extract(new ArrayHeaders());
         $this->assertNull($context->enabled());
         $this->assertFalse($context->fromHeader());
     }
@@ -40,7 +40,9 @@ class B3HeadersPropagatorTest extends TestCase
     {
         $propagator = new B3HeadersPropagator();
         $context = new SpanContext($traceId, $spanId, $enabled);
-        $propagator->inject($context, $output);
+        $headers = new ArrayHeaders();
+        $propagator->inject($context, $headers);
+        $output = $headers->toArray();
 
         $this->assertArrayHasKey('X-B3-TraceId', $output);
         $this->assertArrayHasKey('X-B3-SpanId', $output);

--- a/tests/unit/Trace/Propagator/GrpcMetadataPropagatorTest.php
+++ b/tests/unit/Trace/Propagator/GrpcMetadataPropagatorTest.php
@@ -17,7 +17,7 @@
 
 namespace OpenCensus\Tests\Unit\Trace\Propagator;
 
-use OpenCensus\Trace\SpanContext;
+use OpenCensus\Trace\Propagator\ArrayHeaders;
 use OpenCensus\Trace\Propagator\BinaryFormatter;
 use OpenCensus\Trace\Propagator\GrpcMetadataPropagator;
 use PHPUnit\Framework\TestCase;
@@ -33,7 +33,7 @@ class GrpcMetadataPropagatorTest extends TestCase
     public function testExtract($traceId, $spanId, $enabled, $hex)
     {
         $propagator = new GrpcMetadataPropagator();
-        $context = $propagator->extract(['grpc-trace-bin' => hex2bin($hex)]);
+        $context = $propagator->extract(new ArrayHeaders(['grpc-trace-bin' => hex2bin($hex)]));
         $this->assertEquals($traceId, $context->traceId());
         $this->assertEquals($spanId, $context->spanId());
         $this->assertEquals($enabled, $context->enabled());
@@ -46,7 +46,7 @@ class GrpcMetadataPropagatorTest extends TestCase
     public function testExtractCustomKey($traceId, $spanId, $enabled, $hex)
     {
         $propagator = new GrpcMetadataPropagator(new BinaryFormatter(), 'foobar');
-        $context = $propagator->extract(['foobar' => hex2bin($hex)]);
+        $context = $propagator->extract(new ArrayHeaders(['foobar' => hex2bin($hex)]));
         $this->assertEquals($traceId, $context->traceId());
         $this->assertEquals($spanId, $context->spanId());
         $this->assertEquals($enabled, $context->enabled());

--- a/tests/unit/Trace/Propagator/HttpHeaderPropagatorTest.php
+++ b/tests/unit/Trace/Propagator/HttpHeaderPropagatorTest.php
@@ -17,6 +17,7 @@
 
 namespace OpenCensus\Tests\Unit\Trace\Propagator;
 
+use OpenCensus\Trace\Propagator\ArrayHeaders;
 use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\Propagator\CloudTraceFormatter;
 use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
@@ -33,7 +34,7 @@ class HttpHeaderPropagatorTest extends TestCase
     public function testExtract($traceId, $spanId, $enabled, $header)
     {
         $propagator = new HttpHeaderPropagator();
-        $context = $propagator->extract(['X-Cloud-Trace-Context' => $header]);
+        $context = $propagator->extract(new ArrayHeaders(['X-Cloud-Trace-Context' => $header]));
         $this->assertEquals($traceId, $context->traceId());
         $this->assertEquals($spanId, $context->spanId());
         $this->assertEquals($enabled, $context->enabled());
@@ -46,7 +47,7 @@ class HttpHeaderPropagatorTest extends TestCase
     public function testExtractCustomKey($traceId, $spanId, $enabled, $header)
     {
         $propagator = new HttpHeaderPropagator(new CloudTraceFormatter(), 'Trace-Context');
-        $context = $propagator->extract(['Trace-Context' => $header]);
+        $context = $propagator->extract(new ArrayHeaders(['Trace-Context' => $header]));
         $this->assertEquals($traceId, $context->traceId());
         $this->assertEquals($spanId, $context->spanId());
         $this->assertEquals($enabled, $context->enabled());
@@ -60,9 +61,10 @@ class HttpHeaderPropagatorTest extends TestCase
     {
         $propagator = new HttpHeaderPropagator();
         $context = new SpanContext($traceId, $spanId, $enabled);
-        $propagator->inject($context, $output);
-        $this->assertArrayHasKey('X-Cloud-Trace-Context', $output);
-        $this->assertEquals($header, $output['X-Cloud-Trace-Context']);
+        $headers = new ArrayHeaders();
+        $propagator->inject($context, $headers);
+        $this->assertArrayHasKey('X-Cloud-Trace-Context', $headers);
+        $this->assertEquals($header, $headers->get('X-Cloud-Trace-Context'));
     }
 
     /**
@@ -72,9 +74,10 @@ class HttpHeaderPropagatorTest extends TestCase
     {
         $propagator = new HttpHeaderPropagator(new CloudTraceFormatter(), 'Trace-Context');
         $context = new SpanContext($traceId, $spanId, $enabled);
-        $propagator->inject($context, $output);
-        $this->assertArrayHasKey('Trace-Context', $output);
-        $this->assertEquals($header, $output['Trace-Context']);
+        $headers = new ArrayHeaders();
+        $propagator->inject($context, $headers);
+        $this->assertArrayHasKey('Trace-Context', $headers);
+        $this->assertEquals($header, $headers->get('Trace-Context'));
     }
 
     /**


### PR DESCRIPTION
Inspired by [NodeJS implementation of the propagator](https://github.com/census-instrumentation/opencensus-node/blob/12f184adf46ebeb9e03195004bf42468494deb9c/packages/opencensus-core/src/trace/propagation/types.ts), this PR adds `HeaderSetter`, `HeaderGetter` as parameters for `extract` and `inject` methods of the `PropagatorInterface`.