### PR TITLE
Fix B3 propagator behavior when an empty context is given

### DIFF
--- a/src/Trace/Propagator/B3HeadersPropagator.php
+++ b/src/Trace/Propagator/B3HeadersPropagator.php
@@ -41,7 +41,7 @@ class B3HeadersPropagator implements PropagatorInterface
     public function inject(SpanContext $context, HeaderSetter $headers): void
     {
         $headers->set(self::X_B3_TRACE_ID, $context->traceId());
-        $headers->set(self::X_B3_SPAN_ID, $context->spanId());
+        $headers->set(self::X_B3_SPAN_ID, $context->spanId() ?? '');
         $headers->set(self::X_B3_SAMPLED, $context->enabled() ? 1 : 0);
     }
 }

--- a/tests/unit/Trace/Propagator/B3HeadersPropagatorTest.php
+++ b/tests/unit/Trace/Propagator/B3HeadersPropagatorTest.php
@@ -55,6 +55,23 @@ class B3HeadersPropagatorTest extends TestCase
         $this->assertEquals($sampled, $output['X-B3-Sampled']);
     }
 
+    public function testEmptyContext()
+    {
+        $propagator = new B3HeadersPropagator();
+        $context = new SpanContext();
+        $headers = new ArrayHeaders();
+        $propagator->inject($context, $headers);
+        $output = $headers->toArray();
+
+        $this->assertArrayHasKey('X-B3-TraceId', $output);
+        $this->assertArrayHasKey('X-B3-SpanId', $output);
+        $this->assertArrayHasKey('X-B3-Sampled', $output);
+
+        $this->assertNotEmpty($output['X-B3-TraceId']);
+        $this->assertEquals('', $output['X-B3-SpanId']);
+        $this->assertEquals(0, $output['X-B3-Sampled']);
+    }
+
     public function traceMetadata()
     {
         return [


### PR DESCRIPTION
It was causing TypeError because a string was requested, but null was given.

Duplicate of #17 