### PR TITLE
Remove ExporterInterface::export() return type

### DIFF
--- a/src/Trace/Exporter/ExporterInterface.php
+++ b/src/Trace/Exporter/ExporterInterface.php
@@ -30,5 +30,5 @@ interface ExporterInterface
      * @param SpanData[] $spans
      * @return bool Success of export
      */
-    public function export(array $spans): bool;
+    public function export(array $spans);
 }


### PR DESCRIPTION
There are bunch of third-party packages that depend on this
interface. Adding a specific return type on the interface breaks
the implementation, so we better leave it out.